### PR TITLE
Improved error message in msgcodec-json when required fields are missing.

### DIFF
--- a/msgcodec-json/src/main/java/com/cinnober/msgcodec/json/JsonValueHandler.java
+++ b/msgcodec-json/src/main/java/com/cinnober/msgcodec/json/JsonValueHandler.java
@@ -859,6 +859,10 @@ public abstract class JsonValueHandler<T> {
             return requiredSlot;
         }
 
+        String getName() {
+            return name;
+        }
+
         public JsonValueHandler getValueHandler() {
             return valueHandler;
         }
@@ -937,7 +941,20 @@ public abstract class JsonValueHandler<T> {
             }
 
             if (!requiredFields.isEmpty()) {
-                throw new DecodeException("Some required fields are missing");
+                StringBuilder str = new StringBuilder("Missing required ")
+                        .append(requiredFields.cardinality() == 1 ? "field" : "fields")
+                        .append(": ");
+                boolean comma = false;
+                for (FieldHandler fieldHandler : fields.values()) {
+                    if (fieldHandler.isRequired() && requiredFields.get(fieldHandler.getRequiredSlot())) {
+                        if (comma) {
+                            str.append(", ");
+                        }
+                        str.append(fieldHandler.getName());
+                        comma = true;
+                    }
+                }
+                throw new DecodeException(str.toString());
             }
         }
 


### PR DESCRIPTION
The message "Some required fields are missing" was not that helpful. Now it is replaced with "Missing field(s): fieldName1, fieldName2, ...".