### PR TITLE
Add support for char/Character

### DIFF
--- a/msgcodec-blink/src/test/java/com/cinnober/msgcodec/blink/CharacterTest.java
+++ b/msgcodec-blink/src/test/java/com/cinnober/msgcodec/blink/CharacterTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 The MsgCodec Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.cinnober.msgcodec.blink;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.cinnober.msgcodec.IncompatibleSchemaException;
+import com.cinnober.msgcodec.MsgCodec;
+import com.cinnober.msgcodec.MsgObject;
+import com.cinnober.msgcodec.Schema;
+import com.cinnober.msgcodec.SchemaBuilder;
+import com.cinnober.msgcodec.anot.Id;
+import com.cinnober.msgcodec.anot.Name;
+
+public class CharacterTest {
+
+    public void printStream(ByteArrayOutputStream stream) {
+        byte[] arr = stream.toByteArray();
+
+        for (int i = 0; i < arr.length; i++) {
+            System.out.print(arr[i] & 0xFF);
+            System.out.print(" ");
+        }
+        System.out.println("");
+    }
+
+    @Test
+    public void testCharacter() throws IOException, IncompatibleSchemaException {
+        Schema schema = new SchemaBuilder().build(Version1.class);
+
+        MsgCodec codec = new BlinkCodecFactory(schema).createCodec();
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        codec.encode(new Version1('a', null), bout);
+
+        printStream(bout);
+
+        Version1 msg = (Version1) codec.decode(new ByteArrayInputStream(bout.toByteArray()));
+        assertEquals('a', msg.char1);
+        assertEquals(null, msg.char2);
+    }
+
+    @Test
+    public void testCharacter2() throws IOException, IncompatibleSchemaException {
+        Schema schema = new SchemaBuilder().build(Version1.class);
+
+        MsgCodec codec = new BlinkCodecFactory(schema).createCodec();
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        codec.encode(new Version1('a', 'B'), bout);
+
+        printStream(bout);
+
+        Version1 msg = (Version1) codec.decode(new ByteArrayInputStream(bout.toByteArray()));
+        assertEquals('a', msg.char1);
+        assertEquals((Character) 'B', msg.char2);
+    }
+
+    @Name("Payload")
+    @Id(1)
+    public static class Version1 extends MsgObject {
+        public char char1;
+        public Character char2;
+
+        public Version1() {
+        }
+
+        public Version1(char v1, Character v2) {
+            char1 = v1;
+            char2 = v2;
+        }
+    }
+}

--- a/msgcodec-json/src/main/java/com/cinnober/msgcodec/json/JsonValueHandler.java
+++ b/msgcodec-json/src/main/java/com/cinnober/msgcodec/json/JsonValueHandler.java
@@ -69,6 +69,7 @@ public abstract class JsonValueHandler<T> {
 
     public static final JsonValueHandler<Byte> UINT8 = new UInt8Handler();
     public static final JsonValueHandler<Short> UINT16 = new UInt16Handler();
+    public static final JsonValueHandler<Character> CHAR = new CharacterHandler();
     public static final JsonValueHandler<Integer> UINT32 = new UInt32Handler();
     public static final JsonValueHandler<Long> UINT64 = new UInt64Handler(false);
     public static final JsonValueHandler<Long> UINT64_SAFE = new UInt64Handler(true);
@@ -129,6 +130,9 @@ public abstract class JsonValueHandler<T> {
         case UINT8:
             checkType(javaClass, byte.class, Byte.class);
             return (JsonValueHandler<T>) JsonValueHandler.UINT8;
+        case CHAR:
+            checkType(javaClass, char.class, Character.class);
+            return (JsonValueHandler<T>) JsonValueHandler.CHAR;
         case UINT16:
             checkType(javaClass, short.class, Short.class);
             return (JsonValueHandler<T>) JsonValueHandler.UINT16;
@@ -305,6 +309,17 @@ public abstract class JsonValueHandler<T> {
         @Override
         public Short readValue(JsonParser p) throws IOException {
             return (short) p.getIntValue();
+        }
+    }
+    static class CharacterHandler extends JsonValueHandler<Character> {
+        private CharacterHandler() {}
+        @Override
+        public void writeValue(Character value, JsonGenerator g) throws IOException {
+            g.writeNumber(value.charValue() & 0xffff);
+        }
+        @Override
+        public Character readValue(JsonParser p) throws IOException {
+            return (char) p.getIntValue();
         }
     }
     static class UInt32Handler extends JsonValueHandler<Integer> {

--- a/msgcodec-json/src/test/java/com/cinnober/msgcodec/json/JsonCodecTest.java
+++ b/msgcodec-json/src/test/java/com/cinnober/msgcodec/json/JsonCodecTest.java
@@ -100,6 +100,26 @@ public class JsonCodecTest {
     }
 
     @Test
+    public void testCharacterMessage() throws Exception {
+        Schema schema = new SchemaBuilder().build(CharacterMessage.class);
+        MsgCodec codec = new JsonCodec(schema, false);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CharacterMessage msg = new CharacterMessage('a', 'B', null);
+        codec.encode(msg, out);
+
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        Object msg2 = codec.decode(in);
+        assertEquals(msg, msg2);
+
+        final int chara = new Character('a').charValue();
+        final int charB = new Character('B').charValue();
+        final String data = "{\"$type\":\"CharacterMessage\", \"data1\":" + chara + ", \"data2\":" + charB + "}";
+        in = new ByteArrayInputStream(data.getBytes(Charset.forName("UTF8")));
+        msg2 = codec.decode(in);
+        assertEquals(msg, msg2);
+    }
+
+    @Test
     public void testDecodeNestedTypeOutOfOrder1() throws Exception {
         Schema schema = new SchemaBuilder().build(Nested.class, Hello.class);
         MsgCodec codec = new JsonCodec(schema, false);
@@ -216,6 +236,18 @@ public class JsonCodecTest {
         }
         public BinaryMessage(byte[] data) {
             this.data = data;
+        }
+    }
+    public static class CharacterMessage extends MsgObject {
+        public char data1;
+        public Character data2;
+        public Character data3;
+        public CharacterMessage() {
+        }
+        public CharacterMessage(char data1, Character data2, Character data3) {
+            this.data1 = data1;
+            this.data2 = data2;
+            this.data3 = data3;
         }
     }
     public static abstract class AbstractMessage extends MsgObject {

--- a/msgcodec-test/src/main/java/com/cinnober/msgcodec/test/messages/SequencesMessage.java
+++ b/msgcodec-test/src/main/java/com/cinnober/msgcodec/test/messages/SequencesMessage.java
@@ -48,6 +48,8 @@ public class SequencesMessage extends MsgObject {
     public short[] arrayShorts;
     public int[] arrayInts;
     public long[] arrayLongs;
+    public boolean[] arrayBooleans;
+    public char[] arrayChars;
 
     @Unsigned
     public int[] arrayUInts;
@@ -61,6 +63,10 @@ public class SequencesMessage extends MsgObject {
     public int[] arrayIntsReq;
     @Required
     public long[] arrayLongsReq;
+    @Required
+    public boolean[] arrayBooleansReq;
+    @Required
+    public char[] arrayCharsReq;
 
     @Required @Time
     public long[] arrayTime;
@@ -70,6 +76,12 @@ public class SequencesMessage extends MsgObject {
 
     @Sequence(Integer.class)
     public List<Integer> listInts;
+
+    @Sequence(Boolean.class)
+    public List<Boolean> listBooleans;
+
+    @Sequence(Character.class)
+    public List<Character> listCharacters;
 
     @Unsigned @Sequence(Integer.class)
     public List<Integer> listUInts;
@@ -107,6 +119,8 @@ public class SequencesMessage extends MsgObject {
         msg.arrayShortsReq = new short[]{};
         msg.arrayIntsReq = new int[]{};
         msg.arrayLongsReq = new long[]{};
+        msg.arrayBooleansReq = new boolean[]{};
+        msg.arrayCharsReq = new char[]{};
         msg.arrayTime = new long[]{};
 
         msg = new SequencesMessage();
@@ -115,6 +129,8 @@ public class SequencesMessage extends MsgObject {
         msg.arrayShortsReq = new short[]{};
         msg.arrayIntsReq = new int[]{};
         msg.arrayLongsReq = new long[]{};
+        msg.arrayBooleansReq = new boolean[]{};
+        msg.arrayCharsReq = new char[]{};
         msg.arrayTime = new long[]{};
         msg.arrayEmployees = new Employee[] { createEmployee("Bob", 123), createEmployee("Alice", 456) };
 
@@ -124,6 +140,8 @@ public class SequencesMessage extends MsgObject {
         msg.arrayShortsReq = new short[]{};
         msg.arrayIntsReq = new int[]{};
         msg.arrayLongsReq = new long[]{};
+        msg.arrayBooleansReq = new boolean[]{};
+        msg.arrayCharsReq = new char[]{};
         msg.arrayTime = new long[]{};
         msg.arrayColors = new Color[]{};
         msg.listColors = Arrays.asList();
@@ -134,6 +152,8 @@ public class SequencesMessage extends MsgObject {
         msg.arrayShortsReq = new short[]{};
         msg.arrayIntsReq = new int[]{};
         msg.arrayLongsReq = new long[]{};
+        msg.arrayBooleansReq = new boolean[]{};
+        msg.arrayCharsReq = new char[]{};
         msg.arrayTime = new long[]{};
         msg.arrayColors = new Color[]{ Color.RED };
         msg.listColors = Arrays.asList(Color.RED);
@@ -144,6 +164,8 @@ public class SequencesMessage extends MsgObject {
         msg.arrayShortsReq = new short[]{};
         msg.arrayIntsReq = new int[]{};
         msg.arrayLongsReq = new long[]{};
+        msg.arrayBooleansReq = new boolean[]{};
+        msg.arrayCharsReq = new char[]{};
         msg.arrayTime = new long[]{};
         msg.arrayColors = new Color[]{ Color.GREEN, Color.BLUE };
         msg.listColors = Arrays.asList(Color.GREEN, Color.BLUE);

--- a/msgcodec-test/src/main/java/com/cinnober/msgcodec/test/upgrade/UpgradeBasicMessages.java
+++ b/msgcodec-test/src/main/java/com/cinnober/msgcodec/test/upgrade/UpgradeBasicMessages.java
@@ -42,18 +42,22 @@ public class UpgradeBasicMessages {
                 new PairedTestProtocols.PairedMessages(new ShortNum3((byte)90),new LongNum2((byte)90)));
         testMessages.put("IntToLong",
                 new PairedTestProtocols.PairedMessages(new IntNum3((byte)90),new LongNum3((byte)90)));
+        testMessages.put("CharPrimitiveToCharObject",
+            new PairedTestProtocols.PairedMessages(new CharNum('a'),new OptCharNum('a')));
+        testMessages.put("CharToInt",
+            new PairedTestProtocols.PairedMessages(new CharNum1('\u1234'),new IntNum4('\u1234')));
         return testMessages;
     }
 
     public static Collection<Class<?>> getOriginalSchemaClasses() {
         return Arrays.asList(DecimalNarrow.class, ByteNum.class, ByteNum2.class, ByteNum3.class, ByteNum4.class,
-                ShortNum2.class, ShortNum3.class, IntNum3.class);
+                ShortNum2.class, ShortNum3.class, IntNum3.class, CharNum.class, CharNum1.class);
 
     }
 
     public static Collection<Class<?>> getUpgradedSchemaClasses() {
         return Arrays.asList(DecimalWide.class, OptByteNum.class, ShortNum.class, IntNum.class, LongNum.class,
-                IntNum2.class, LongNum2.class, LongNum3.class);
+                IntNum2.class, LongNum2.class, LongNum3.class, OptCharNum.class, IntNum4.class);
     }
 
     @Name("Decimal")
@@ -219,6 +223,42 @@ public class UpgradeBasicMessages {
 
         public LongNum3() {}
         public LongNum3(int n) { this.n = n; }
+    }
+
+    @Name("Number8")
+    @Id(1008)
+    public static class CharNum extends MsgObject {
+        public char n;
+
+        public CharNum() {}
+        public CharNum(char n) { this.n = n; }
+    }
+
+    @Name("Number8")
+    @Id(1008)
+    public static class OptCharNum extends MsgObject {
+        public Character n;
+
+        public OptCharNum() {}
+        public OptCharNum(Character n) { this.n = n; }
+    }
+
+    @Name("Number9")
+    @Id(1009)
+    public static class CharNum1 extends MsgObject {
+        public char n;
+
+        public CharNum1() {}
+        public CharNum1(char n) { this.n = n; }
+    }
+
+    @Name("Number9")
+    @Id(1009)
+    public static class IntNum4 extends MsgObject {
+        public int n;
+
+        public IntNum4() {}
+        public IntNum4(int n) { this.n = n; }
     }
 
     public enum EnumNarrow {

--- a/msgcodec-xml/src/main/java/com/cinnober/msgcodec/xml/XmlCodec.java
+++ b/msgcodec-xml/src/main/java/com/cinnober/msgcodec/xml/XmlCodec.java
@@ -415,6 +415,8 @@ public class XmlCodec implements MsgCodec {
             return XmlNumberFormat.INT64;
         case UINT8:
             return XmlNumberFormat.UINT8;
+        case CHAR:
+            return XmlNumberFormat.CHAR;
         case UINT16:
             return XmlNumberFormat.UINT16;
         case UINT32:

--- a/msgcodec-xml/src/main/java/com/cinnober/msgcodec/xml/XmlNumberFormat.java
+++ b/msgcodec-xml/src/main/java/com/cinnober/msgcodec/xml/XmlNumberFormat.java
@@ -39,6 +39,7 @@ abstract class XmlNumberFormat<T> implements XmlFormat<T> {
     public static final Int64NumberFormat INT64 = new Int64NumberFormat();
 
     public static final UInt8NumberFormat UINT8 = new UInt8NumberFormat();
+    public static final CharacterNumberFormat CHAR = new CharacterNumberFormat();
     public static final UInt16NumberFormat UINT16 = new UInt16NumberFormat();
     public static final UInt32NumberFormat UINT32 = new UInt32NumberFormat();
     public static final UInt64NumberFormat UINT64 = new UInt64NumberFormat();
@@ -161,6 +162,16 @@ abstract class XmlNumberFormat<T> implements XmlFormat<T> {
         @Override
         public Short parse(String str) throws FormatException {
             return (short) parseUInt(str);
+        }
+    }
+    public static class CharacterNumberFormat extends XmlNumberFormat<Character> {
+        @Override
+        public String format(Character value) {
+            return formatInt(0xffffL & value);
+        }
+        @Override
+        public Character parse(String str) throws FormatException {
+            return (char) parseUInt(str);
         }
     }
     public static class UInt8NumberFormat extends XmlNumberFormat<Byte> {

--- a/msgcodec-xml/src/test/java/com/cinnober/msgcodec/xml/XmlCodecTest.java
+++ b/msgcodec-xml/src/test/java/com/cinnober/msgcodec/xml/XmlCodecTest.java
@@ -23,20 +23,23 @@
  */
 package com.cinnober.msgcodec.xml;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.cinnober.msgcodec.Annotations;
 import com.cinnober.msgcodec.DecodeException;
-import com.cinnober.msgcodec.Schema;
-import com.cinnober.msgcodec.SchemaBuilder;
 import com.cinnober.msgcodec.MsgCodec;
 import com.cinnober.msgcodec.MsgObject;
+import com.cinnober.msgcodec.Schema;
+import com.cinnober.msgcodec.SchemaBuilder;
 import com.cinnober.msgcodec.anot.Dynamic;
 import com.cinnober.msgcodec.anot.Required;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.Charset;
 
 /**
  * @author mikael.brannstrom
@@ -166,6 +169,17 @@ public class XmlCodecTest {
         codec.decode(in);
     }
 
+    @Test
+    public void testDecodeCharacter() throws Exception {
+        Schema schema = new SchemaBuilder().build(TestChar.class);
+        XmlCodec codec = new XmlCodec(schema);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.encode(new TestChar('a', 'B'), out);
+        final byte[] encoded = out.toByteArray();
+        final TestChar decoded = (TestChar) codec.decode(new ByteArrayInputStream(encoded));
+        assertEquals('a', decoded.data1);
+        assertEquals((Character) 'B', decoded.data2);
+    }
 
     public static class Hello {
         @Required
@@ -223,7 +237,15 @@ public class XmlCodecTest {
                     + "]";
         }
     }
-
+    public static class TestChar {
+        public char data1;
+        public Character data2;
+        public TestChar() {}
+        public TestChar(char d1, Character d2) {
+            this.data1 = d1;
+            this.data2 = d2;
+        }
+    }
     public static abstract class AbstractMessage extends MsgObject {
     }
 

--- a/msgcodec/src/main/java/com/cinnober/msgcodec/CreateAccessor.java
+++ b/msgcodec/src/main/java/com/cinnober/msgcodec/CreateAccessor.java
@@ -58,6 +58,9 @@ public final class CreateAccessor<O, V> implements Accessor<O, V> {
                 if(field.getType().getType() == Type.INT16 || field.getType().getType() == Type.UINT16) {
                     value = (V) Short.valueOf((short) 0);
                 }
+                else if(field.getType().getType() == Type.CHAR) {
+                    value = (V) Character.valueOf((char) 0);
+                }
                 else if(field.getType().getType() == Type.BOOLEAN) {
                     value = (V) Boolean.valueOf(false);
                 }
@@ -86,6 +89,9 @@ public final class CreateAccessor<O, V> implements Accessor<O, V> {
             if(field.getJavaClass() == short.class) {
                 value = (V) Short.valueOf((short) 0);
             }
+            else if(field.getJavaClass() == char.class) {
+                value = (V) Character.valueOf((char) 0);
+            } 
             else if(field.getJavaClass() == int.class) {
                 value = (V) Integer.valueOf(0);
             }

--- a/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBinder.java
+++ b/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBinder.java
@@ -469,7 +469,10 @@ public class SchemaBinder {
             case UINT16:
                 return new ConverterAccessor<>(accessor, SchemaBinder::uByteToShort, SchemaBinder::invalidConversion);
             case CHAR:
-                return new ConverterAccessor<>(accessor, SchemaBinder::uByteToChar, SchemaBinder::invalidConversion);
+                if (srcType.getType() == Type.UINT8) {
+                    return new ConverterAccessor<>(accessor, SchemaBinder::uByteToChar, SchemaBinder::invalidConversion);
+                }
+                return null;
             case INT32:
                 return new ConverterAccessor<>(accessor, SchemaBinder::byteToInt, SchemaBinder::invalidConversion);
             case UINT32:

--- a/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBinder.java
+++ b/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBinder.java
@@ -378,6 +378,8 @@ public class SchemaBinder {
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::shortToLong);
             case UINT16:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::uShortToLong);
+            case CHAR:
+                return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::charToLong);
             case INT8:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::byteToLong);
             case UINT8:
@@ -392,6 +394,8 @@ public class SchemaBinder {
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::shortToInt);
             case UINT16:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::uShortToInt);
+            case CHAR:
+                return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::charToInt);
             case INT8:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::byteToInt);
             case UINT8:
@@ -402,10 +406,25 @@ public class SchemaBinder {
         case INT16:
         case UINT16:
             switch (dstType.getType()) {
+            case CHAR:
+                if (srcType.getType() == Type.UINT16) {
+                    return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::charToShort);
+                } else {
+                    return null;
+                }
             case INT8:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::byteToShort);
             case UINT8:
                 return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::uByteToShort);
+            default:
+                return null;
+            }
+        case CHAR:
+            switch (dstType.getType()) {
+            case UINT8:
+                return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::uByteToChar);
+            case UINT16:
+                return new ConverterAccessor<>(accessor, SchemaBinder::invalidConversion, SchemaBinder::uShortToChar);
             default:
                 return null;
             }
@@ -449,6 +468,8 @@ public class SchemaBinder {
                 return new ConverterAccessor<>(accessor, SchemaBinder::byteToShort, SchemaBinder::invalidConversion);
             case UINT16:
                 return new ConverterAccessor<>(accessor, SchemaBinder::uByteToShort, SchemaBinder::invalidConversion);
+            case CHAR:
+                return new ConverterAccessor<>(accessor, SchemaBinder::uByteToChar, SchemaBinder::invalidConversion);
             case INT32:
                 return new ConverterAccessor<>(accessor, SchemaBinder::byteToInt, SchemaBinder::invalidConversion);
             case UINT32:
@@ -457,6 +478,20 @@ public class SchemaBinder {
                 return new ConverterAccessor<>(accessor, SchemaBinder::byteToLong, SchemaBinder::invalidConversion);
             case UINT64:
                 return new ConverterAccessor<>(accessor, SchemaBinder::uByteToLong, SchemaBinder::invalidConversion);
+            default:
+                return null;
+            }
+
+        case CHAR:
+            switch (dstType.getType()) {
+            case UINT16:
+                return new ConverterAccessor<>(accessor, SchemaBinder::charToShort, SchemaBinder::invalidConversion);
+            case INT32:
+            case UINT32:
+                return new ConverterAccessor<>(accessor, SchemaBinder::charToInt, SchemaBinder::invalidConversion);
+            case INT64:
+            case UINT64:
+                return new ConverterAccessor<>(accessor, SchemaBinder::charToLong, SchemaBinder::invalidConversion);
             default:
                 return null;
             }
@@ -572,6 +607,14 @@ public class SchemaBinder {
         return (short) (v & 0xff);
     }
 
+    private static Character uByteToChar(Byte v) {
+        return (char) (v & 0xff);
+    }
+
+    private static Character uShortToChar(Short v) {
+        return (char)(v & 0xffff);
+    }
+
     private static Integer uByteToInt(Byte v) {
         return v & 0xff;
     }
@@ -584,7 +627,19 @@ public class SchemaBinder {
         return v & 0xffff;
     }
 
+    private static Integer charToInt(Character v) {
+        return v & 0xffff;
+    }
+
+    private static Short charToShort(Character v) {
+        return (short)v.charValue();
+    }
+
     private static Long uShortToLong(Short v) {
+        return v & 0xffffL;
+    }
+
+    private static Long charToLong(Short v) {
         return v & 0xffffL;
     }
 

--- a/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBuilder.java
+++ b/msgcodec/src/main/java/com/cinnober/msgcodec/SchemaBuilder.java
@@ -115,6 +115,7 @@ public class SchemaBuilder {
                     BigInteger.class,
                     Date.class,
                     boolean.class, Boolean.class,
+                    char.class, Character.class,
                     String.class,
                     byte[].class
                     )));
@@ -764,6 +765,9 @@ public class SchemaBuilder {
         } else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
             assertNotAnnotated(type.getName(), unsignedAnot, dynamicAnot, smallDecimalAnot, maxSizeAnot);
             return TypeDef.BOOLEAN;
+        } else if (type.equals(char.class) || type.equals(Character.class)) {
+            assertNotAnnotated(type.getName(), dynamicAnot, smallDecimalAnot, maxSizeAnot);
+            return TypeDef.CHAR;
         }
 
         // reference

--- a/msgcodec/src/main/java/com/cinnober/msgcodec/TypeDef.java
+++ b/msgcodec/src/main/java/com/cinnober/msgcodec/TypeDef.java
@@ -163,6 +163,10 @@ public abstract class TypeDef {
          * @see TypeDef#UINT8
          */
         UINT8,
+        /** 16-bit unicode character (unsigned 16-bit integer). Java type: char or Character.
+         * @see TypeDef#CHAR
+         */
+        CHAR,
         /** Unsigned 16-bit integer. Java type: short or Short.
          * @see TypeDef#UINT16
          */
@@ -248,6 +252,7 @@ public abstract class TypeDef {
     }
 
     public static final TypeDef UINT8 = new Simple(Type.UINT8, Byte.class, "u8", MetaTypeDef.UINT8);
+    public static final TypeDef CHAR = new Simple(Type.CHAR, Character.class, "u16", MetaTypeDef.UINT16);
     public static final TypeDef UINT16 = new Simple(Type.UINT16, Short.class, "u16", MetaTypeDef.UINT16);
     public static final TypeDef UINT32 = new Simple(Type.UINT32, Integer.class, "u32", MetaTypeDef.UINT32);
     public static final TypeDef UINT64 = new Simple(Type.UINT64, Long.class, "u64", MetaTypeDef.UINT64);


### PR DESCRIPTION
Character/char is the only Java primitive type currently not supported.
These changes add char/Character support, sending it as a uint16 over the wire.