### PR TITLE
Bug-fix; Avoid NoSuchMethodError in generated bytecode

### DIFF
--- a/msgcodec-blink/src/main/java/com/cinnober/msgcodec/blink/BaseByteCodeGenerator.java
+++ b/msgcodec-blink/src/main/java/com/cinnober/msgcodec/blink/BaseByteCodeGenerator.java
@@ -2451,7 +2451,7 @@ class BaseByteCodeGenerator {
             String genClassInternalName,
             Class<?> javaClass, TypeDef type, boolean javaClassCodec) throws IllegalArgumentException {
         if (refGroup != null) {
-            String groupDescriptor = getTypeDescriptor(javaClass,javaClassCodec);
+            String groupDescriptor = getTypeDescriptor(refGroup.getGroupType(), javaClassCodec);
             if (required) {
                 mv.visitInsn(POP); // input stream
                 mv.visitVarInsn(ALOAD, 0);


### PR DESCRIPTION
Bug-fix; Use Java class value specified in the referenced group instead of originating field. Apparently this was already done in generateEncodeRefValue.

Trigger this bug using ProtocolUpgradeExample with BlinkCodec.